### PR TITLE
replace devcenter components with extensions

### DIFF
--- a/guides/example/page_functionality_wix_sdk.md
+++ b/guides/example/page_functionality_wix_sdk.md
@@ -2,7 +2,7 @@
 
 In the Business Buddy app, on the **Products** page, users can choose a product from the site's Wix Store.
 
-To work with the Wix apps on a user's site, we use the [Wix Dashboard React SDK](https://dev.wix.com/docs/sdk/api-reference/dashboard-react/introduction) and the [Wix React SDK](https://dev.wix.com/docs/sdk/api-reference/sdk-react/setup). We already showed how to set up your page components with the Dashboard React SDK in [the previous section](https://dev.wix.com/docs/build-apps/developer-tools/cli/example-app-walkthrough/page-design). In this section, we'll use the React SDK to retrieve site data to display in the app.
+To work with the Wix apps on a user's site, we use the [Wix Dashboard React SDK](https://dev.wix.com/docs/sdk/api-reference/dashboard-react/introduction) and the [Wix React SDK](https://dev.wix.com/docs/sdk/api-reference/sdk-react/setup). We already showed how to set up your page extensions with the Dashboard React SDK in [the previous section](https://dev.wix.com/docs/build-apps/developer-tools/cli/example-app-walkthrough/page-design). In this section, we'll use the React SDK to retrieve site data to display in the app.
 
 ## Permissions
 
@@ -28,7 +28,7 @@ These imports give us access to the Wix SDK overall and the particular functiona
 
 ---
 
-Once we import everything, we'll use the [`useWixModules()`](https://dev.wix.com/docs/sdk/api-reference/sdk-react/hooks#usewixmodules) hook create an initialized copy of the `products` module that we can use directly in our page component code. We retrieve the `products` module's [`queryProducts()`](https://dev.wix.com/api/sdk/stores/products/queryproducts) function that we can use to access store products. 
+Once we import everything, we'll use the [`useWixModules()`](https://dev.wix.com/docs/sdk/api-reference/sdk-react/hooks#usewixmodules) hook create an initialized copy of the `products` module that we can use directly in our page extension code. We retrieve the `products` module's [`queryProducts()`](https://dev.wix.com/api/sdk/stores/products/queryproducts) function that we can use to access store products.
 
 ```tsx
 const { queryProducts } = useWixModules(products);

--- a/guides/framework/framework_features.md
+++ b/guides/framework/framework_features.md
@@ -1,12 +1,12 @@
 # App Framework Features
 
-The Wix App Framework is a React-based framework that allows you to build apps for Wix sites. The framework provides a way to define app components, their React based UI, styling and more.
+The Wix App Framework is a React-based framework that allows you to build apps for Wix sites. The framework provides a way to define app extensions, their React based UI, styling and more.
 
 The Wix App Framework is:
 
 - **React-based**: Use React components to define your app's UI. You can use React components from the [Wix Design System](https://www.wixdesignsystem.com/) to build your app's UI or bring your own components.
 - **Boilerplate-free**: You don't have to write any boilerplate code. Focus on your app's business logic and let the framework handle the rest.
-- **Declarative**: Define your app's components and their UI in a declarative manner using React and the app manifest.
+- **Declarative**: Define your app's extensions and their UI in a declarative manner using React and the app manifest.
 
 ## Vite
 
@@ -25,7 +25,7 @@ We suggest you read the [Vite Features Guide](https://vitejs.dev/guide/features.
 
 ## App manifest
 
-The app manifest is a declarative definition of your app's components and their UI, including:
+The app manifest is a declarative definition of your app's extensions and their UI, including:
 
 - Dashboard pages
 - Sidebar configurations

--- a/guides/framework/working_with_wix_apis.md
+++ b/guides/framework/working_with_wix_apis.md
@@ -31,7 +31,7 @@ To read more about adding permissions to your app, see [Adding Permissions to yo
 
 When developing [dashboard pages](dashboard_pages.md), your code can access APIs with the permissions of the currently logged in user, but scoped to the permissions your app has been granted.
 
-This means that the permissions available in a dashboard component's code are the intersection of the permissions your app has been granted and the permissions of the user that is currently logged in to the Wix Dashboard.
+This means that the permissions available in a dashboard extension's code are the intersection of the permissions your app has been granted and the permissions of the user that is currently logged in to the Wix Dashboard.
 
 ![Dashboard Permissions](../../media/dashboard_permissions.png)
 

--- a/guides/workflow/app_versions_and_deployment.md
+++ b/guides/workflow/app_versions_and_deployment.md
@@ -56,7 +56,7 @@ npm run preview
 yarn preview
 ```
 
-This will create and display preview URLs for the various components in your app. You can send these URLs to team members who are [collaborators](https://support.wix.com/en/article/inviting-people-to-contribute-to-your-site) on your development site so they can preview and test changes. You can also use the preview URLs to test your app using browser testing tools like [Puppeteer](https://pptr.dev/), [Selenium](https://saucelabs.com/selenium-getting-started), or [Playwright](https://playwright.dev/).
+This will create and display preview URLs for the various extensions in your app. You can send these URLs to team members who are [collaborators](https://support.wix.com/en/article/inviting-people-to-contribute-to-your-site) on your development site so they can preview and test changes. You can also use the preview URLs to test your app using browser testing tools like [Puppeteer](https://pptr.dev/), [Selenium](https://saucelabs.com/selenium-getting-started), or [Playwright](https://playwright.dev/).
 
 ## Deployable version
 

--- a/guides/workflow/integrate_with_existing_apps.md
+++ b/guides/workflow/integrate_with_existing_apps.md
@@ -2,7 +2,7 @@
 
 You can use the Wix CLI for Apps to work with existing apps that are already registered in the Wix Developers Center. This allows you to add new features to your app using the CLI without having to migrate the entire app to your CLI project.
 
-Because the Wix CLI for Apps is a new tool, it does not yet support all Wix App Platform features. By working with both the Developers Center and the CLI you can continue to create and manage existing app components in the Developers Center, while still using the CLI for its current capabilities.
+Because the Wix CLI for Apps is a new tool, it does not yet support all Wix App Platform features. By working with both the Developers Center and the CLI you can continue to create and manage existing app extensionss in the Developers Center, while still using the CLI for its current capabilities.
 
 ## Extend an existing app
 
@@ -11,10 +11,10 @@ To extend an existing app with a new Wix CLI for Apps project:
 1. Choose **Extend existing application** when [creating a new project](../start/quick_start.md#create-a-new-app-project)
 1. Choose the existing app to extend
 
-When working on the CLI extension project locally (or in preview versions), you will only be able to work with the app components that are registered in the Wix CLI project. The app components from the Developer Center will still be loaded into your development site, but they will use their production versions.
+When working on the CLI extension project locally (or in preview versions), you will only be able to work with the app extensions that are registered in the Wix CLI project. The app extensions from the Developer Center will still be loaded into your development site, but they will use their production versions.
 
 ## Release a new version
 
 When you are ready to release a new version of your extended app, use the CLI to [create a new version and upload it to the CDN](./app_versions_and_deployment.md).
 
-It's important to note that when you create a new app version from the CLI, it also includes any changes that you made in other app components that are not registered in the Wix CLI project. Take this into account when creating a new app version and ensure that your other app components are ready to be released.
+It's important to note that when you create a new app version from the CLI, it also includes any changes that you made in other app extensions that are not registered in the Wix CLI project. Take this into account when creating a new app version and ensure that your other app extensions are ready to be released.


### PR DESCRIPTION
After DevCenter changed `Component` to `Extension`, we should also reflect this in our docs