### PR TITLE
docs: use dashboard-react

### DIFF
--- a/guides/framework/dashboard_pages.md
+++ b/guides/framework/dashboard_pages.md
@@ -105,7 +105,7 @@ The content is defined as a [React](https://react.dev/) component that renders w
 
 Inside a dashboard page component you can use:
 
-- The [Dashboard SDK](https://dev.wix.com/docs/client/api-reference/dashboard-sdk/intro) to navigate users to pages in the dashboard, display modals, and send users alerts and updates using toasts.
+- The [Wix Dashboard React SDK](https://dev.wix.com/docs/sdk/api-reference/dashboard-react/introduction) to navigate users to pages in the dashboard, display modals, and send users alerts and updates using toasts.
 - The [Wix Design System](https://www.docs.wixdesignsystem.com/?path=/story/getting-started--about) to use the same React components Wix uses to build its own dashboard pages.
 
 ### Page Routes

--- a/guides/start/platform_overview.md
+++ b/guides/start/platform_overview.md
@@ -45,9 +45,9 @@ A dashboard toast is a message that appears at the top of the dashboard.
 
 ![Dashboard toast](../../media/dashboard_toast.png)
 
-### Dashboard SDK
+### Wix Dashboard React SDK
 
-When building dashboard pages, you can use the [Dashboard SDK](https://dev.wix.com/docs/client/api-reference/dashboard-sdk/intro) to interact with the dashboard from your app.
+When building dashboard pages, you can use the [Wix Dashboard React SDK](https://dev.wix.com/docs/sdk/api-reference/dashboard-react/introduction) to interact with the dashboard from your app.
 
 You can use the SDK to:
 

--- a/guides/start/quick_start.md
+++ b/guides/start/quick_start.md
@@ -97,7 +97,7 @@ Let's make a small change in the boilerplate code to see how you edit your proje
 1. Save the file and go back to the browser.
 1. Click the button again to see the new toast message.
 
-To learn more about working with the Dashboard SDK and its different methods, see the [Dashboard SDK](https://dev.wix.com/docs/client/api-reference/dashboard-sdk/intro).
+To learn more about working with the Dashboard SDK and its different methods, see the [Wix Dashboard React SDK](https://dev.wix.com/docs/sdk/api-reference/dashboard-react/introduction).
 
 ## Build the app
 
@@ -170,5 +170,5 @@ You now have a fully working app that can be installed on Wix sites. Take some t
 Use the following resources to continue building you app:
 
 - [Dashboard Pages](../framework/dashboard_pages.md): Learn how to add new dashboard pages to your app, configure the dashboard sidebar, and more.
-- [Dashboard SDK](https://dev.wix.com/docs/client/api-reference/dashboard-sdk/intro): Learn how to interact with the Wix Dashboard using the Dashboard SDK.
+- [Wix Dashboard React SDK](https://dev.wix.com/docs/sdk/api-reference/dashboard-react/introduction): Learn how to interact with the Wix Dashboard using the Dashboard SDK.
 - [Wix Design System](https://wixdesignsystem.com): Learn how to use the Wix Design System to build beautiful Wix Apps.


### PR DESCRIPTION
Suggest the new `@wix/dashboard-react` sdk.

[Working with Wix APIs](https://dev.wix.com/docs/build-apps/developer-tools/cli/wix-cli-for-apps/working-with-wix-apis) is still wrong and using the non-react version of the SDKs, but updating it requires rewriting most of the tutorial so let's take this separately.